### PR TITLE
update dependencies and peerDependencies to satisfy recent installations without using --force

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,32 @@
 {
-  "name": "expo-unlimited-secure-store",
-  "version": "1.0.9",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "crypto-js": {
-      "version": "3.1.9-1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+    "name": "@neverdull-agency/expo-unlimited-secure-store",
+    "version": "1.0.9",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@neverdull-agency/expo-unlimited-secure-store",
+            "version": "1.0.9",
+            "license": "MIT",
+            "dependencies": {
+                "crypto-js": "^4.0.0"
+            },
+            "peerDependencies": {
+                "expo-file-system": "^9.3.0",
+                "expo-secure-store": "^9.3.0"
+            }
+        },
+        "node_modules/crypto-js": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+            "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+        }
+    },
+    "dependencies": {
+        "crypto-js": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+            "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+        }
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,38 +1,38 @@
 {
-  "name": "@neverdull-agency/expo-unlimited-secure-store",
-  "version": "1.0.9",
-  "description": "An 'unlimited' secure store engine for expo projects, also compatible with redux-persist. (Expo's SecureStore was limited to 2KB in SDK v33)",
-  "main": "src/index.js",
-  "types": "src/index.d.ts",
-  "peerDependencies": {
-    "expo-file-system": "^5.0.1",
-    "expo-secure-store": "^5.0.1"
-  },
-  "dependencies": {
-    "crypto-js": "^3.1.9-1"
-  },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/neverdull-agency/expo-unlimited-secure-store.git"
-  },
-  "keywords": [
-    "expo",
-    "unlimited",
-    "secure",
-    "store",
-    "redux",
-    "persist",
-    "large",
-    "secured",
-    "storage"
-  ],
-  "author": "Istvan Szilagyi <istvan@neverdull.nl>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/neverdull-agency/expo-unlimited-secure-store/issues"
-  },
-  "homepage": "https://github.com/neverdull-agency/expo-unlimited-secure-store#readme"
+    "name": "@neverdull-agency/expo-unlimited-secure-store",
+    "version": "1.0.9",
+    "description": "An 'unlimited' secure store engine for expo projects, also compatible with redux-persist. (Expo's SecureStore was limited to 2KB in SDK v33)",
+    "main": "src/index.js",
+    "types": "src/index.d.ts",
+    "peerDependencies": {
+        "expo-file-system": "^9.3.0",
+        "expo-secure-store": "^9.3.0"
+    },
+    "dependencies": {
+        "crypto-js": "^4.0.0"
+    },
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/neverdull-agency/expo-unlimited-secure-store.git"
+    },
+    "keywords": [
+        "expo",
+        "unlimited",
+        "secure",
+        "store",
+        "redux",
+        "persist",
+        "large",
+        "secured",
+        "storage"
+    ],
+    "author": "Istvan Szilagyi <istvan@neverdull.nl>",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/neverdull-agency/expo-unlimited-secure-store/issues"
+    },
+    "homepage": "https://github.com/neverdull-agency/expo-unlimited-secure-store#readme"
 }


### PR DESCRIPTION
Thanks for your work!

In recent project using current versions of npm for development, the installation fails. Since npm@7, there is strict peerDependency checking. Thus, when not using `--force` or `--legacy-peer-deps` parameter during installs, such as in CI/CD pipelines, installation will fail.

Please consider merging this pull request or implementing yourself to match current up-to-date dependencies.

I also updated crypto-js since its always safer to be up-to-date with security dependencies.